### PR TITLE
[ID-64] Handle group membership request for Core BB tokens

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -10,7 +10,8 @@ type Services interface {
 	GetVersion() string
 
 	GetGroupCategories() ([]string, error)
-	GetUserGroupMemberships(externalID string) ([]*model.Group, *model.User, error)
+	GetUserGroupMembershipsByID(id string) ([]*model.Group, error)
+	GetUserGroupMembershipsByExternalID(externalID string) ([]*model.Group, *model.User, error)
 
 	GetGroupEntity(clientID string, id string) (*model.Group, error)
 	GetGroupEntityByMembership(clientID string, membershipID string) (*model.Group, error)
@@ -52,8 +53,14 @@ func (s *servicesImpl) GetVersion() string {
 func (s *servicesImpl) GetGroupCategories() ([]string, error) {
 	return s.app.getGroupCategories()
 }
-func (s *servicesImpl) GetUserGroupMemberships(externalID string) ([]*model.Group, *model.User, error) {
-	return s.app.getUserGroupMemberships(externalID)
+
+func (s *servicesImpl) GetUserGroupMembershipsByID(id string) ([]*model.Group, error) {
+	memberships, _, err := s.app.getUserGroupMemberships(id, false)
+	return memberships, err
+}
+
+func (s *servicesImpl) GetUserGroupMembershipsByExternalID(externalID string) ([]*model.Group, *model.User, error) {
+	return s.app.getUserGroupMemberships(externalID, true)
 }
 
 func (s *servicesImpl) GetGroupEntity(clientID string, id string) (*model.Group, error) {
@@ -165,7 +172,7 @@ type Storage interface {
 	RefactorUser(clientID string, current *model.User, newID string) (*model.User, error)
 
 	ReadAllGroupCategories() ([]string, error)
-	FindUserGroupsMemberships(externalID string) ([]*model.Group, *model.User, error)
+	FindUserGroupsMemberships(id string, external bool) ([]*model.Group, *model.User, error)
 
 	CreateGroup(clientID string, title string, description *string, category string, tags []string, privacy string, creatorUserID string, creatorName string, creatorPhotoURL string, imageURL *string, webURL *string, membershipQuestions []string) (*string, *GroupError)
 	UpdateGroup(clientID string, id string, category string, title string, privacy string, description *string,

--- a/core/services.go
+++ b/core/services.go
@@ -315,8 +315,8 @@ func (app *Application) getGroupCategories() ([]string, error) {
 	}
 	return groupCategories, nil
 }
-func (app *Application) getUserGroupMemberships(externalID string) ([]*model.Group, *model.User, error) {
-	getUserGroupMemberships, user, err := app.storage.FindUserGroupsMemberships(externalID)
+func (app *Application) getUserGroupMemberships(id string, external bool) ([]*model.Group, *model.User, error) {
+	getUserGroupMemberships, user, err := app.storage.FindUserGroupsMemberships(id, external)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/driven/storage/adapter.go
+++ b/driven/storage/adapter.go
@@ -223,19 +223,26 @@ func (sa *Adapter) RefactorUser(clientID string, current *model.User, newID stri
 }
 
 //FindUserGroupsMemberships stores user group membership
-func (sa *Adapter) FindUserGroupsMemberships(externalID string) ([]*model.Group, *model.User, error) {
-	filter := bson.D{primitive.E{Key: "external_id", Value: externalID}}
-	var result []*model.User
-	err := sa.db.users.Find(filter, &result, nil)
-	if err != nil {
-		return nil, nil, err
+func (sa *Adapter) FindUserGroupsMemberships(id string, external bool) ([]*model.Group, *model.User, error) {
+	userID := ""
+	var err error
+	var user *model.User
+	if external {
+		filter := bson.D{primitive.E{Key: "external_id", Value: id}}
+		var result []*model.User
+		err := sa.db.users.Find(filter, &result, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		if result == nil || len(result) == 0 {
+			//not found
+			return nil, nil, nil
+		}
+		user = result[0]
+		userID = user.ID
+	} else {
+		userID = id
 	}
-	if result == nil || len(result) == 0 {
-		//not found
-		return nil, nil, nil
-	}
-	user := result[0]
-	userID := user.ID
 
 	filterID := bson.D{primitive.E{Key: "members.user_id", Value: userID}}
 	var resultList []*group

--- a/driver/web/adapter.go
+++ b/driver/web/adapter.go
@@ -68,7 +68,7 @@ func (we *Adapter) Start() {
 	adminSubrouter.HandleFunc("/groups", we.adminIDTokenAuthWrapFunc(we.adminApisHandler.GetAllGroups)).Methods("GET")
 
 	//internal key protection
-	restSubrouter.HandleFunc("/int/user/{identifier}/groups", we.internalKeyAuthFunc(we.apisHandler.GetUserGroupMemberships)).Methods("GET")
+	restSubrouter.HandleFunc("/int/user/{identifier}/groups", we.internalKeyAuthFunc(we.apisHandler.IntGetUserGroupMemberships)).Methods("GET")
 
 	//api key protection
 	restSubrouter.HandleFunc("/group-categories", we.apiKeysAuthWrapFunc(we.apisHandler.GetGroupCategories)).Methods("GET")
@@ -77,6 +77,7 @@ func (we *Adapter) Start() {
 	restSubrouter.HandleFunc("/groups", we.idTokenAuthWrapFunc(we.apisHandler.CreateGroup)).Methods("POST")
 	restSubrouter.HandleFunc("/groups/{id}", we.idTokenAuthWrapFunc(we.apisHandler.UpdateGroup)).Methods("PUT")
 	restSubrouter.HandleFunc("/user/groups", we.idTokenAuthWrapFunc(we.apisHandler.GetUserGroups)).Methods("GET")
+	restSubrouter.HandleFunc("/user/group-memberships", we.idTokenAuthWrapFunc(we.apisHandler.GetUserGroupMemberships)).Methods("GET")
 	restSubrouter.HandleFunc("/group/{id}", we.idTokenAuthWrapFunc(we.apisHandler.DeleteGroup)).Methods("DELETE")
 	restSubrouter.HandleFunc("/group/{group-id}/pending-members", we.idTokenAuthWrapFunc(we.apisHandler.CreatePendingMember)).Methods("POST")
 	restSubrouter.HandleFunc("/group/{group-id}/pending-members", we.idTokenAuthWrapFunc(we.apisHandler.DeletePendingMember)).Methods("DELETE")


### PR DESCRIPTION
Resolves #64.

Hi @mdryankov, please let me know what you think of this approach. Essentially the Events BB will forward the user token (whether it is Shibboleth or Core) to the Groups BB instead of parsing the UIN out of the token and using a special API key. This will allow the Events BB to support private events for auth types other than `illinois_oidc` without having to redo all the work to figure out what type of user it is on the Events BB before making the request. Thanks!