### PR TITLE
[ID-69] Events manager tokens rejected

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,12 +46,13 @@ func main() {
 	host := getEnvKey("GR_HOST", true)
 	oidcProvider := getEnvKey("GR_OIDC_PROVIDER", true)
 	oidcClientID := getEnvKey("GR_OIDC_CLIENT_ID", true)
+	oidcExtendedClientIDs := getEnvKey("GR_OIDC_EXTENDED_CLIENT_IDS", false)
 	oidcAdminClientID := getEnvKey("GR_OIDC_ADMIN_CLIENT_ID", true)
 	oidcAdminWebClientID := getEnvKey("GR_OIDC_ADMIN_WEB_CLIENT_ID", true)
 	coreBBHost := getEnvKey("CORE_BB_HOST", false)
 	groupServiceURL := getEnvKey("GROUP_SERVICE_URL", false)
 
-	webAdapter := web.NewWebAdapter(application, host, apiKeys, oidcProvider, oidcClientID, oidcAdminClientID, oidcAdminWebClientID, internalAPIKeys, coreBBHost, groupServiceURL)
+	webAdapter := web.NewWebAdapter(application, host, apiKeys, oidcProvider, oidcClientID, oidcExtendedClientIDs, oidcAdminClientID, oidcAdminWebClientID, internalAPIKeys, coreBBHost, groupServiceURL)
 	webAdapter.Start()
 }
 


### PR DESCRIPTION
Resolves #69

Hi @mdryankov, here are the necessary changes to allow multiple OIDC clients to access the `/user/group-memberships` endpoint as needed by the events manager app. I have tested this locally and it seems like it is working as expected and will resolve the issue. We need these changes to proceed with https://github.com/rokwire/rokwire-building-blocks-api/pull/813, so please prioritize review of this PR and deploy the changes to the dev environment if it looks good to you. Let me know if you have any questions or concerns. Thanks!

**Note**: I resolved another issue in this PR. It looks like there is a unique compound index in the users collection for `clientID`/`externalID`. We were leaving the `externalID` blank for auth types other than OIDC for core tokens, but this will prevent them from being able to create users since they will all have the same `externalID` (""). I decided to always use the UID from the Core tokens as the `externalID` to avoid this issue. 