### PR TITLE
- Deprecate ROKWIRE_GS_API_KEY and start using only INTERNAL-API-KEY …

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -150,7 +150,7 @@
         "filename": "driver/web/auth.go",
         "hashed_secret": "45b2e8300605777bea57e3ffe5144279b0dc465a",
         "is_verified": false,
-        "line_number": 314,
+        "line_number": 304,
         "is_secret": false
       }
     ],
@@ -181,5 +181,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-12T12:28:31Z"
+  "generated_at": "2022-07-12T13:02:14Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - Expose netID within the membership & user records [#184](https://github.com/rokwire/groups-building-block/issues/163)
+- Deprecate ROKWIRE_GS_API_KEY and start using only INTERNAL-API-KEY as internal API authentication mechanism. This  a redo operations of a previous redo changes due to a confirmation [#156](https://github.com/rokwire/groups-building-block/issues/156)
 
 ## [1.5.49] - 2022-07-07
 - Additional fix for missing member.id on requesting for a group membership [#163](https://github.com/rokwire/groups-building-block/issues/163)

--- a/driver/web/adapter.go
+++ b/driver/web/adapter.go
@@ -253,11 +253,11 @@ func (we Adapter) adminIDTokenAuthWrapFunc(handler adminAuthFunc) http.HandlerFu
 
 //NewWebAdapter creates new WebAdapter instance
 func NewWebAdapter(app *core.Application, host string, appKeys []string, oidcProvider string, oidcClientID string,
-	oidcExtendedClientIDs string, oidcAdminClientID string, oidcAdminWebClientID string, legacyInternalAPIKeys []string,
+	oidcExtendedClientIDs string, oidcAdminClientID string, oidcAdminWebClientID string,
 	internalAPIKey string, authService *authservice.AuthService, groupServiceURL string) *Adapter {
 	authorization := casbin.NewEnforcer("driver/web/authorization_model.conf", "driver/web/authorization_policy.csv")
 
-	auth := NewAuth(app, host, appKeys, legacyInternalAPIKeys, internalAPIKey, oidcProvider, oidcClientID, oidcExtendedClientIDs, oidcAdminClientID,
+	auth := NewAuth(app, host, appKeys, internalAPIKey, oidcProvider, oidcClientID, oidcExtendedClientIDs, oidcAdminClientID,
 		oidcAdminWebClientID, authService, groupServiceURL, authorization)
 	apisHandler := rest.NewApisHandler(app)
 	adminApisHandler := rest.NewAdminApisHandler(app)

--- a/driver/web/auth.go
+++ b/driver/web/auth.go
@@ -185,7 +185,7 @@ func (auth *Auth) getIDToken(r *http.Request) *string {
 }
 
 //NewAuth creates new auth handler
-func NewAuth(app *core.Application, host string, appKeys []string, legacyInternalAPIKeys []string, internalAPIKey string, oidcProvider string, oidcClientID string, oidcExtendedClientIDs string,
+func NewAuth(app *core.Application, host string, appKeys []string, internalAPIKey string, oidcProvider string, oidcClientID string, oidcExtendedClientIDs string,
 	oidcAdminClientID string, oidcAdminWebClientID string, authService *authservice.AuthService, groupServiceURL string, adminAuthorization *casbin.Enforcer) *Auth {
 	var tokenAuth *tokenauth.TokenAuth
 	if authService != nil {
@@ -202,7 +202,7 @@ func NewAuth(app *core.Application, host string, appKeys []string, legacyInterna
 
 	apiKeysAuth := newAPIKeysAuth(appKeys, tokenAuth)
 	idTokenAuth := newIDTokenAuth(app, oidcProvider, oidcClientID, oidcExtendedClientIDs, tokenAuth)
-	internalAuth := newInternalAuth(legacyInternalAPIKeys, internalAPIKey)
+	internalAuth := newInternalAuth(internalAPIKey)
 	adminAuth := newAdminAuth(app, oidcProvider, oidcAdminClientID, oidcAdminWebClientID, tokenAuth, adminAuthorization)
 
 	supportedClients := []string{"edu.illinois.rokwire", "edu.illinois.covid"}
@@ -271,8 +271,7 @@ type userData struct {
 
 //InternalAuth entity
 type InternalAuth struct {
-	legacyInternalAPIKeys []string
-	internalAPIKey        string
+	internalAPIKey string
 }
 
 // TBD Remove the legacy API key functionality
@@ -291,14 +290,6 @@ func (auth *InternalAuth) check(internalAPIKey *string, w http.ResponseWriter) b
 		return true
 	}
 
-	//check if the api key is one of the listed
-	appKeys := auth.legacyInternalAPIKeys
-	for _, element := range appKeys {
-		if element == *internalAPIKey {
-			return true
-		}
-	}
-
 	//not exist, so return 401
 	log.Println(fmt.Sprintf("401 - Unauthorized for key %s", *internalAPIKey))
 
@@ -308,10 +299,9 @@ func (auth *InternalAuth) check(internalAPIKey *string, w http.ResponseWriter) b
 }
 
 //newInternalAuth creates new internal auth
-func newInternalAuth(legacyInternalAPIKeys []string, internalAPIKey string) *InternalAuth {
+func newInternalAuth(internalAPIKey string) *InternalAuth {
 	auth := InternalAuth{
-		legacyInternalAPIKeys: legacyInternalAPIKeys,
-		internalAPIKey:        internalAPIKey,
+		internalAPIKey: internalAPIKey,
 	}
 	return &auth
 }

--- a/main.go
+++ b/main.go
@@ -110,7 +110,6 @@ func main() {
 
 	//web adapter
 	apiKeys := getAPIKeys()
-	internalAPIKeys := getInternalAPIKeys()
 	host := getEnvKey("GR_HOST", true)
 	oidcProvider := getEnvKey("GR_OIDC_PROVIDER", true)
 	oidcClientID := getEnvKey("GR_OIDC_CLIENT_ID", true)
@@ -120,7 +119,7 @@ func main() {
 
 	webAdapter := web.NewWebAdapter(application, host, apiKeys, oidcProvider,
 		oidcClientID, oidcExtendedClientIDs, oidcAdminClientID, oidcAdminWebClientID,
-		internalAPIKeys, intrernalAPIKey, authService, groupServiceURL)
+		intrernalAPIKey, authService, groupServiceURL)
 	webAdapter.Start()
 }
 
@@ -135,18 +134,6 @@ func getAPIKeys() []string {
 	}
 
 	return rokwireAPIKeysList
-}
-func getInternalAPIKeys() []string {
-	//get from the environment
-	internalAPIKeys := getEnvKey("GR_GS_API_KEYS", true)
-
-	//it is comma separated format
-	rokwireInternalAPIKeysList := strings.Split(internalAPIKeys, ",")
-	if len(rokwireInternalAPIKeysList) <= 0 {
-		log.Fatal("Keys list is empty")
-	}
-
-	return rokwireInternalAPIKeysList
 }
 
 func getEnvKey(key string, required bool) string {


### PR DESCRIPTION
…as internal API authentication mechanism. This  a redo operations of a previous redo changes due to a confirmation [#156]