### PR TITLE
[ID-257]Set privacy members dependence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Addend
+- Set privacy members dependence [#257](https://github.com/rokwire/groups-building-block/issues/257)
 
 ## [1.5.70] - 2022-09-19
 ### Fixed

--- a/driven/storage/adapter.go
+++ b/driven/storage/adapter.go
@@ -2547,6 +2547,30 @@ func constructMember(member member) model.Member {
 	}
 }
 
+func constructPublicMember(member *model.Member) model.Member {
+	id := member.ID
+	userID := member.UserID
+	netID := member.NetID
+	name := member.Name
+	photoURL := member.PhotoURL
+	status := member.Status
+	rejectReason := member.RejectReason
+	dateCreated := member.DateCreated
+	dateUpdated := member.DateUpdated
+	dateAttended := member.DateAttended
+
+	memberAnswers := make([]model.MemberAnswer, len(member.MemberAnswers))
+	for i, current := range member.MemberAnswers {
+		memberAnswers[i] = model.MemberAnswer{Question: current.Question, Answer: current.Answer}
+	}
+
+	publicMember := model.Member{ID: id, UserID: userID, NetID: netID, Name: name, PhotoURL: photoURL,
+		Status: status, RejectReason: rejectReason, DateCreated: dateCreated, DateUpdated: dateUpdated, MemberAnswers: memberAnswers,
+		DateAttended: dateAttended}
+	return publicMember
+
+}
+
 type storageListener struct {
 	adapter *Adapter
 	DefaultListenerImpl

--- a/driven/storage/adapter_v2.go
+++ b/driven/storage/adapter_v2.go
@@ -2,8 +2,9 @@ package storage
 
 import (
 	"fmt"
-	"go.mongodb.org/mongo-driver/mongo/options"
 	"groups/core/model"
+
+	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -147,7 +148,12 @@ func (sa Adapter) GetGroupMembers(clientID string, groupID string, filter *model
 	if resultLength > 0 {
 		resultList = make([]model.Member, resultLength)
 		for index, member := range list {
-			resultList[index] = member.Member
+			if group.Privacy != "public" {
+				resultList[index] = member.Member
+			} else {
+
+				resultList[index] = constructPublicMember(&member.Member)
+			}
 		}
 	}
 	return resultList, nil


### PR DESCRIPTION
The response that i get is:
[
    {
        "id": "6ad86602-af39-11ec-b099-0a58a9feac02",
        "user_id": "79ba5e09-3d42-11ec-bd94-0a58a9feac02",
        "external_id": "",
        "name": "Misho Varbanov",
        "net_id": "varbanov",
        "email": "",
        "photo_url": "",
        "status": "admin",
        "reject_reason": "",
        "member_answers": [],
        "date_created": "2022-03-29T08:22:48.22Z",
        "date_updated": "2022-09-19T10:13:43.844Z",
        "date_attended": null
    }
]

the "external_id" and "email" are still there but if the privacy of the group is !=public the API returns an empty string. I've been trying to remove the lines, but i couldn't. Please take a look at it and tell me if i should remove them or you are ok with this.
Thanks.